### PR TITLE
Fix multigrapher drag bugs: duplicated series, wrong drop targets, color collisions, remount storms

### DIFF
--- a/src/components/y_axis.jsx
+++ b/src/components/y_axis.jsx
@@ -157,7 +157,7 @@ function YAxis({ stateController, showAxes, showGrid, showSeriesKey, axis, sideI
             window.removeEventListener('mouseup', onMouseUp);
 
             let target = mouseUpEvent.target;
-            while (target && !(target.dataset || {}).axisIndex) {
+            while (target && !(target.dataset || {}).axisIndex && !(target.dataset || {}).grapherId) {
                 target = target.parentNode;
             }
 

--- a/src/grapher.jsx
+++ b/src/grapher.jsx
@@ -155,6 +155,12 @@ function Grapher(props) {
     }, [stateController]);
 
     useEffect(() => {
+        // in a multigrapher, a grapher can shift position (and thus id) without
+        // remounting; drag-and-drop target resolution relies on the current id
+        stateController.grapherID = props.id;
+    }, [stateController, props.id]);
+
+    useEffect(() => {
         if (stateController.disposed) {
             // Replacement is scheduled; this re-runs with the fresh instance.
             return;

--- a/src/multigrapher.jsx
+++ b/src/multigrapher.jsx
@@ -95,7 +95,7 @@ function MultiGrapher(props) {
             {
                 multiSeries.map((series, i) =>
                     <Grapher
-                        key={`${controllerGeneration}-${i}`}
+                        key={`${controllerGeneration}-${multigraphStateController.graphKeyAt(i)}`}
                         {...props}
                         syncPool={syncPool}
                         stateControllerInitialization={multigraphStateController.stateControllerInitialization}

--- a/src/renderer/graph_body_renderer.js
+++ b/src/renderer/graph_body_renderer.js
@@ -33,8 +33,7 @@ export default class GraphBodyRenderer extends Eventable {
                 this._lineProgram = new LineProgram(this._context);
                 this._shadowProgram = new ShadowProgram(this._context);
             } else {
-                console.error('❌ WebGL context creation failed');
-                alert('WebGL failed! Attempting fallback to CPU rendering');
+                console.error('WebGL context creation failed; falling back to CPU rendering');
                 this._webgl = false;
             }
         }

--- a/src/renderer/size_canvas.js
+++ b/src/renderer/size_canvas.js
@@ -23,7 +23,7 @@ export default async function sizeCanvas(canvas, context, {reset=true}={}) {
 
     while (boundingRect.width === 0) {
         await new Promise((resolve) => requestAnimationFrame(resolve));
-        boundingRect = canvas.getBoundingClientRect();
+        boundingRect = canvas.parentNode.getBoundingClientRect();
     }
 
     const dpr = window.devicePixelRatio || 1;

--- a/src/state/multigraph_state_controller.js
+++ b/src/state/multigraph_state_controller.js
@@ -1,5 +1,5 @@
 import Eventable from '../eventable.js';
-import getColor from '../helpers/colors.js';
+import getColor, {LINE_COLORS} from '../helpers/colors.js';
 import nameForSeries from '../helpers/name_for_series.js';
 
 export default class MultigraphStateController extends Eventable {
@@ -16,6 +16,7 @@ export default class MultigraphStateController extends Eventable {
         this._originalSeriesByMultigrapherIndex = new Map();
         this._stateControllers = new Set();
         this._prevSeries = [];
+        this._nextMultigrapherSeriesIndex = 0;
 
         this._dataCache = new Map();
         this._subscriptions = new Map();
@@ -55,8 +56,20 @@ export default class MultigraphStateController extends Eventable {
 
         this._prevSeries = series;
 
-        const graphIndices = new Set();
         const currentSeriesSet = new Set(series);
+
+        // prune bookkeeping for series that are no longer present, freeing their colors
+        for (let [originalSeries, modifiedSeries] of [...this._modifiedSeries]) {
+            if (!currentSeriesSet.has(originalSeries)) {
+                this._modifiedSeries.delete(originalSeries);
+                this._originalSeriesByMultigrapherIndex.delete(modifiedSeries.multigrapherSeriesIndex);
+                this._seriesToGraphIndices.delete(originalSeries);
+            }
+        }
+
+        // group by graph: a graph the series was previously placed in (e.g. by dragging)
+        // wins over the graph requested in the series definition
+        const graphBuckets = new Map();
 
         for (let singleSeries of series) {
             let graphIndex = singleSeries.graph || 0;
@@ -65,65 +78,117 @@ export default class MultigraphStateController extends Eventable {
                 graphIndex = this._seriesToGraphIndices.get(singleSeries);
             }
 
-            graphIndices.add(graphIndex);
-
-            let seriesSet = this._graphIndicesToSeries.get(graphIndex);
-            if (!seriesSet) {
-                seriesSet = new Set();
-                this._graphIndicesToSeries.set(graphIndex, seriesSet);
+            graphIndex = parseInt(graphIndex);
+            if (!Number.isFinite(graphIndex) || graphIndex < 0) {
+                graphIndex = 0;
             }
 
-            seriesSet.add(singleSeries);
+            let bucket = graphBuckets.get(graphIndex);
+            if (!bucket) {
+                bucket = [];
+                graphBuckets.set(graphIndex, bucket);
+            }
+
+            bucket.push(singleSeries);
         }
 
-        const sortedGraphIndices = [...graphIndices].sort();
+        const sortedGraphIndices = [...graphBuckets.keys()].sort((a, b) => a - b);
+
+        const usedColors = new Set();
+        for (let singleSeries of series) {
+            const modifiedSeries = this._modifiedSeries.get(singleSeries);
+            if (modifiedSeries) {
+                usedColors.add(modifiedSeries.color);
+            }
+        }
 
         this._multiSeries = [];
-        let globalSeriesIndex = 0;
 
         for (let graphIndex of sortedGraphIndices) {
-            const series = [];
+            const graphSeries = [];
 
-            for (let singleSeries of this._graphIndicesToSeries.get(graphIndex)) {
-                if (!currentSeriesSet.has(singleSeries)) {
-                    this._graphIndicesToSeries.get(graphIndex).delete(singleSeries);
-                    continue;
+            for (let singleSeries of graphBuckets.get(graphIndex)) {
+                let modifiedSeries = this._modifiedSeries.get(singleSeries);
+
+                if (!modifiedSeries) {
+                    const seriesIndex = this._nextMultigrapherSeriesIndex++;
+                    const color = this._pickColor(singleSeries, seriesIndex, usedColors);
+                    usedColors.add(color);
+
+                    modifiedSeries = {
+                        ...singleSeries,
+                        multigrapherSeriesIndex: seriesIndex,
+                        color,
+                        name: nameForSeries(singleSeries, seriesIndex)
+                    };
+
+                    this._modifiedSeries.set(singleSeries, modifiedSeries);
+                    this._originalSeriesByMultigrapherIndex.set(seriesIndex, singleSeries);
                 }
 
-                if (this._modifiedSeries.has(singleSeries)) {
-                    globalSeriesIndex++;
-                    series.push(this._modifiedSeries.get(singleSeries));
-                    continue;
-                }
-
-                const color = getColor(singleSeries.color, globalSeriesIndex);
-                const name = nameForSeries(singleSeries, globalSeriesIndex);
-                const modifiedSeries = {
-                    ...singleSeries,
-                    multigrapherSeriesIndex: globalSeriesIndex,
-                    multigrapherGraphIndex: graphIndex,
-                    color,
-                    name
-                };
-
-                this._modifiedSeries.set(singleSeries, modifiedSeries);
-                this._originalSeriesByMultigrapherIndex.set(globalSeriesIndex, singleSeries);
-
-                globalSeriesIndex++;
-                series.push(modifiedSeries);
+                graphSeries.push(modifiedSeries);
             }
 
-            this._multiSeries.push(series);
+            this._multiSeries.push(graphSeries);
         }
 
-        if (this._nextMultigrapherSeriesIndex) {
-            this._nextMultigrapherSeriesIndex = this._nextMultigrapherSeriesIndex - this._multiSeriesCount + globalSeriesIndex;
-        } else {
-            this._nextMultigrapherSeriesIndex = globalSeriesIndex;
-        }
-        this._multiSeriesCount = globalSeriesIndex;
+        this._renumberGraphs();
 
         this.emit('multi_series_changed', this.multiSeries);
+    }
+
+    /**
+     * Picks a color for a new series: an explicitly requested one if present,
+     * otherwise the first line color not currently in use
+     *
+     * @param {Object} singleSeries
+     * @param {Number} seriesIndex
+     * @param {Set<String>} usedColors
+     * @return {String}
+     * @private
+     */
+    _pickColor(singleSeries, seriesIndex, usedColors) {
+        if (typeof singleSeries.color === 'string' || typeof singleSeries.color === 'number') {
+            return getColor(singleSeries.color, seriesIndex);
+        }
+
+        for (let color of LINE_COLORS) {
+            if (!usedColors.has(color)) {
+                return color;
+            }
+        }
+
+        return getColor(undefined, seriesIndex);
+    }
+
+    /**
+     * Restores the invariants after any change to _multiSeries:
+     * no empty graphs, and every series' multigrapherGraphIndex matches the
+     * position of its graph so drop targets (which are identified by rendered
+     * position) always resolve to the right graph
+     *
+     * @private
+     */
+    _renumberGraphs() {
+        this._multiSeries = this._multiSeries.filter((graphSeries) => graphSeries.length);
+        this._graphIndicesToSeries = new Map();
+        this._seriesToGraphIndices = new Map();
+
+        for (let graphIndex = 0; graphIndex < this._multiSeries.length; graphIndex++) {
+            const originalSeriesSet = new Set();
+
+            for (let modifiedSeries of this._multiSeries[graphIndex]) {
+                modifiedSeries.multigrapherGraphIndex = graphIndex;
+
+                const originalSeries = this._originalSeriesByMultigrapherIndex.get(modifiedSeries.multigrapherSeriesIndex);
+                if (originalSeries) {
+                    originalSeriesSet.add(originalSeries);
+                    this._seriesToGraphIndices.set(originalSeries, graphIndex);
+                }
+            }
+
+            this._graphIndicesToSeries.set(graphIndex, originalSeriesSet);
+        }
     }
 
     /**
@@ -191,107 +256,49 @@ export default class MultigraphStateController extends Eventable {
 
         const originalSeries = this._originalSeriesByMultigrapherIndex.get(draggedSeries.multigrapherSeriesIndex);
         const modifiedSeries = this._modifiedSeries.get(originalSeries);
-
-        this._multiSeries[modifiedSeries.multigrapherGraphIndex].splice(
-            this._multiSeries[modifiedSeries.multigrapherGraphIndex].indexOf(modifiedSeries), 1
-        );
-        this._multiSeries[modifiedSeries.multigrapherGraphIndex] = [...this._multiSeries[modifiedSeries.multigrapherGraphIndex]];
-
-        if (graphIndex === 'top') {
-            modifiedSeries.multigrapherGraphIndex = this._createGraphAtTop();
-        } else if (graphIndex === 'bottom') {
-            modifiedSeries.multigrapherGraphIndex = this._createGraphAtBottom();
-        } else {
-            modifiedSeries.multigrapherGraphIndex = parseInt(graphIndex);
+        if (!modifiedSeries) {
+            return;
         }
+
+        // remove it from whichever graph currently holds it
+        // (searched rather than indexed so a stale multigrapherGraphIndex can never desync us)
+        for (let graphSeries of this._multiSeries) {
+            const seriesPosition = graphSeries.indexOf(modifiedSeries);
+            if (seriesPosition !== -1) {
+                graphSeries.splice(seriesPosition, 1);
+            }
+        }
+
+        // note: the source graph may now be empty, but it must keep its position
+        // until after the target is resolved, since numeric drop targets refer to
+        // the positions that were rendered when the drag started
+        let targetSeries;
+        if (graphIndex === 'top') {
+            targetSeries = [];
+            this._multiSeries.unshift(targetSeries);
+        } else if (graphIndex === 'bottom') {
+            targetSeries = [];
+            this._multiSeries.push(targetSeries);
+        } else {
+            targetSeries = this._multiSeries[parseInt(graphIndex)];
+            if (!targetSeries) {
+                targetSeries = [];
+                this._multiSeries.push(targetSeries);
+            }
+        }
+        targetSeries.push(modifiedSeries);
 
         modifiedSeries.axisIndex = axisIndex;
         // safe because stateController operates on a copy. We could also have changed the identify of modifiedSeries,
         // but with that we might reset data when moving it back
         delete modifiedSeries.axis;
 
-        this._multiSeries[modifiedSeries.multigrapherGraphIndex] = [...this._multiSeries[modifiedSeries.multigrapherGraphIndex], modifiedSeries];
-        this._multiSeries = [...this._multiSeries];
-
-        for (let graphIndex = 0; graphIndex < this._multiSeries.length; graphIndex++) {
-            const originalSeriesAtIndex = this._multiSeries[graphIndex].map(({ multigrapherSeriesIndex  }) =>
-                this._originalSeriesByMultigrapherIndex.get(multigrapherSeriesIndex));
-            this._graphIndicesToSeries.set(graphIndex, new Set(originalSeriesAtIndex));
-
-            for (let singleSeries of originalSeriesAtIndex) {
-                this._seriesToGraphIndices.set(singleSeries, graphIndex);
-            }
-        }
+        // fresh array identities so react and the child state controllers pick up the change
+        this._multiSeries = this._multiSeries.map((graphSeries) => [...graphSeries]);
+        this._renumberGraphs();
 
         this.emit('multi_series_changed', this.multiSeries);
         this.emit('graph_count_changed', this.graphCount, prevGraphCount);
-    }
-
-    /**
-     * Finds or creates an empty graph at the beginning and returns its index
-     *
-     * @return {number}
-     * @private
-     */
-    _createGraphAtTop() {
-        // check if there's anything at the beginning already
-        let emptyAtTopIndex = null;
-
-        for (let i = 0; i < this._multiSeries.length; i++) {
-            if (this._multiSeries[i].length === 0) {
-                emptyAtTopIndex = i;
-            } else {
-                break;
-            }
-        }
-
-        if (emptyAtTopIndex !== null) {
-            return emptyAtTopIndex;
-        }
-
-        // add a series at the beginning and mutate the graph index of each
-        this._multiSeries = [[], ...this._multiSeries];
-        for (let graphIndex = 0; graphIndex < this._multiSeries.length; graphIndex++) {
-            if (!this._multiSeries[graphIndex].length) {
-                continue;
-            }
-
-            this._multiSeries[graphIndex] = [...this._multiSeries[graphIndex]];
-
-            for (let modifiedSeries of this._multiSeries[graphIndex]) {
-                modifiedSeries.multigrapherGraphIndex = graphIndex;
-            }
-        }
-
-        return 0;
-    }
-
-    /**
-     * Finds or creates an empty graph at the end and returns its index
-     *
-     * @return {number}
-     * @private
-     */
-    _createGraphAtBottom() {
-        // check if there's anything at the beginning already
-        let emptyAtBottomIndex = null;
-
-        for (let i = this._multiSeries.length - 1; i >= 0; i--) {
-            if (this._multiSeries[i].length === 0) {
-                emptyAtBottomIndex = i;
-            } else {
-                break;
-            }
-        }
-
-        if (emptyAtBottomIndex !== null) {
-            return emptyAtBottomIndex;
-        }
-
-        // add something at the bottom
-        this._multiSeries = [...this._multiSeries, []];
-
-        return this._multiSeries.length - 1;
     }
 
     get multiSeries() {

--- a/src/state/multigraph_state_controller.js
+++ b/src/state/multigraph_state_controller.js
@@ -17,6 +17,8 @@ export default class MultigraphStateController extends Eventable {
         this._stateControllers = new Set();
         this._prevSeries = [];
         this._nextMultigrapherSeriesIndex = 0;
+        this._graphIds = [];
+        this._nextGraphId = 0;
 
         this._dataCache = new Map();
         this._subscriptions = new Map();
@@ -170,7 +172,19 @@ export default class MultigraphStateController extends Eventable {
      * @private
      */
     _renumberGraphs() {
-        this._multiSeries = this._multiSeries.filter((graphSeries) => graphSeries.length);
+        const keptSeries = [];
+        const keptIds = [];
+        for (let i = 0; i < this._multiSeries.length; i++) {
+            if (!this._multiSeries[i].length) {
+                continue;
+            }
+
+            keptSeries.push(this._multiSeries[i]);
+            keptIds.push(this._graphIds[i] !== undefined ? this._graphIds[i] : this._nextGraphId++);
+        }
+        this._multiSeries = keptSeries;
+        this._graphIds = keptIds;
+
         this._graphIndicesToSeries = new Map();
         this._seriesToGraphIndices = new Map();
 
@@ -276,14 +290,17 @@ export default class MultigraphStateController extends Eventable {
         if (graphIndex === 'top') {
             targetSeries = [];
             this._multiSeries.unshift(targetSeries);
+            this._graphIds.unshift(this._nextGraphId++);
         } else if (graphIndex === 'bottom') {
             targetSeries = [];
             this._multiSeries.push(targetSeries);
+            this._graphIds.push(this._nextGraphId++);
         } else {
             targetSeries = this._multiSeries[parseInt(graphIndex)];
             if (!targetSeries) {
                 targetSeries = [];
                 this._multiSeries.push(targetSeries);
+                this._graphIds.push(this._nextGraphId++);
             }
         }
         targetSeries.push(modifiedSeries);
@@ -303,6 +320,17 @@ export default class MultigraphStateController extends Eventable {
 
     get multiSeries() {
         return this._multiSeries.filter((series) => series.length);
+    }
+
+    /**
+     * A stable identity for the graph at the given position, usable as a react
+     * key so existing graphs don't remount when one is added above them
+     *
+     * @param {Number} graphIndex
+     * @return {Number}
+     */
+    graphKeyAt(graphIndex) {
+        return this._graphIds[graphIndex] !== undefined ? this._graphIds[graphIndex] : graphIndex;
     }
 
     get series() {

--- a/src/state/state_controller.js
+++ b/src/state/state_controller.js
@@ -1545,6 +1545,10 @@ export default class StateController extends Eventable {
         return this._grapherID;
     }
 
+    set grapherID(grapherID) {
+        this._grapherID = grapherID;
+    }
+
     get annotationState() {
         return this._annotationsState;
     }

--- a/test/multigraph_state_controller.test.js
+++ b/test/multigraph_state_controller.test.js
@@ -1,0 +1,226 @@
+import MultigraphStateController from '../src/state/multigraph_state_controller';
+import {LINE_COLORS} from '../src/helpers/colors';
+
+function makeSeries(name, extra = {}) {
+    return { name, data: [[0, 1], [1, 2]], ...extra };
+}
+
+function controller() {
+    return new MultigraphStateController({ id: 'test' });
+}
+
+function graphNames(msc) {
+    return msc.multiSeries.map((graph) => graph.map(({ name }) => name));
+}
+
+function findModified(msc, name) {
+    for (let graph of msc.multiSeries) {
+        for (let singleSeries of graph) {
+            if (singleSeries.name === name) {
+                return singleSeries;
+            }
+        }
+    }
+    return null;
+}
+
+describe('MultigraphStateController', () => {
+    it('splits series into graphs by their graph property', () => {
+        const msc = controller();
+        msc.setSeries([makeSeries('a'), makeSeries('b', { graph: 1 })]);
+
+        expect(graphNames(msc)).to.deep.equal([['a'], ['b']]);
+    });
+
+    it('compacts sparse graph indices while preserving order', () => {
+        const msc = controller();
+        msc.setSeries([makeSeries('a', { graph: 4 }), makeSeries('b', { graph: 2 })]);
+
+        expect(graphNames(msc)).to.deep.equal([['b'], ['a']]);
+        expect(findModified(msc, 'b').multigrapherGraphIndex).to.equal(0);
+        expect(findModified(msc, 'a').multigrapherGraphIndex).to.equal(1);
+    });
+
+    it('sorts graph indices numerically, not lexicographically', () => {
+        const msc = controller();
+        const series = [];
+        for (let i = 0; i < 11; i++) {
+            series.push(makeSeries(`s${i}`, { graph: i }));
+        }
+        msc.setSeries(series);
+
+        expect(graphNames(msc).map(([name]) => name)).to.deep.equal(series.map(({ name }) => name));
+    });
+
+    it('moves a series to a new bottom graph and keeps state dense', () => {
+        const msc = controller();
+        msc.setSeries([makeSeries('a'), makeSeries('b')]);
+
+        msc.moveSeries({ draggedSeries: findModified(msc, 'a'), axisIndex: 'new-left', graphIndex: 'bottom' });
+
+        expect(graphNames(msc)).to.deep.equal([['b'], ['a']]);
+        expect(msc._multiSeries.every((graph) => graph.length > 0)).to.equal(true);
+        expect(findModified(msc, 'b').multigrapherGraphIndex).to.equal(0);
+        expect(findModified(msc, 'a').multigrapherGraphIndex).to.equal(1);
+    });
+
+    it('moves a series to a new top graph and renumbers the rest', () => {
+        const msc = controller();
+        msc.setSeries([makeSeries('a'), makeSeries('b')]);
+
+        msc.moveSeries({ draggedSeries: findModified(msc, 'b'), axisIndex: 'new-left', graphIndex: 'top' });
+
+        expect(graphNames(msc)).to.deep.equal([['b'], ['a']]);
+        expect(findModified(msc, 'b').multigrapherGraphIndex).to.equal(0);
+        expect(findModified(msc, 'a').multigrapherGraphIndex).to.equal(1);
+    });
+
+    it('resolves numeric drop targets against rendered positions after a graph was emptied', () => {
+        const msc = controller();
+        msc.setSeries([makeSeries('a'), makeSeries('b', { graph: 1 }), makeSeries('c', { graph: 2 })]);
+
+        // empty out the first graph; b and c become rendered graphs 0 and 1
+        msc.moveSeries({ draggedSeries: findModified(msc, 'a'), axisIndex: '0', graphIndex: '1' });
+        expect(graphNames(msc)).to.deep.equal([['b', 'a'], ['c']]);
+
+        // dropping onto rendered graph 1 must land on the graph containing c
+        msc.moveSeries({ draggedSeries: findModified(msc, 'a'), axisIndex: '0', graphIndex: '1' });
+        expect(graphNames(msc)).to.deep.equal([['b'], ['c', 'a']]);
+    });
+
+    it('never duplicates a series across graphs through repeated moves and updates', () => {
+        const msc = controller();
+        const a = makeSeries('a');
+        const b = makeSeries('b');
+        const c = makeSeries('c');
+        msc.setSeries([a, b, c]);
+
+        msc.moveSeries({ draggedSeries: findModified(msc, 'a'), axisIndex: '0', graphIndex: 'bottom' });
+        msc.setSeries([a, b, c]);
+        msc.moveSeries({ draggedSeries: findModified(msc, 'b'), axisIndex: '0', graphIndex: 'bottom' });
+        msc.setSeries([a, b, c]);
+
+        const seen = graphNames(msc).flat().sort();
+        expect(seen).to.deep.equal(['a', 'b', 'c']);
+    });
+
+    it('removes a series everywhere when it disappears from the series list, even after dragging', () => {
+        const msc = controller();
+        const a = makeSeries('a');
+        const b = makeSeries('b');
+        msc.setSeries([a, b]);
+        msc.moveSeries({ draggedSeries: findModified(msc, 'a'), axisIndex: '0', graphIndex: 'bottom' });
+
+        msc.setSeries([b]);
+
+        expect(graphNames(msc)).to.deep.equal([['b']]);
+    });
+
+    it('keeps a dragged placement when the same series objects are set again', () => {
+        const msc = controller();
+        const a = makeSeries('a');
+        const b = makeSeries('b');
+        msc.setSeries([a, b]);
+        msc.moveSeries({ draggedSeries: findModified(msc, 'a'), axisIndex: '0', graphIndex: 'bottom' });
+
+        msc.setSeries([a, b]);
+
+        expect(graphNames(msc)).to.deep.equal([['b'], ['a']]);
+    });
+
+    it('honors the graph property when a series is recreated with a new identity', () => {
+        // mirrors how tacoma recreates series objects, persisting placement via the graph property
+        const msc = controller();
+        const a = makeSeries('a');
+        const b = makeSeries('b');
+        msc.setSeries([a, b]);
+        msc.moveSeries({ draggedSeries: findModified(msc, 'a'), axisIndex: '0', graphIndex: 'bottom' });
+
+        const graphOfA = findModified(msc, 'a').multigrapherGraphIndex;
+        msc.setSeries([makeSeries('a', { graph: graphOfA }), b]);
+
+        expect(graphNames(msc)).to.deep.equal([['b'], ['a']]);
+    });
+
+    it('moves the right series even when a stale copy of the dragged series is passed', () => {
+        const msc = controller();
+        msc.setSeries([makeSeries('a'), makeSeries('b')]);
+
+        const staleCopy = { ...findModified(msc, 'a') };
+        msc.moveSeries({ draggedSeries: staleCopy, axisIndex: '0', graphIndex: 'bottom' });
+
+        expect(graphNames(msc)).to.deep.equal([['b'], ['a']]);
+    });
+
+    it('ignores moves for series that no longer exist', () => {
+        const msc = controller();
+        const a = makeSeries('a');
+        const b = makeSeries('b');
+        msc.setSeries([a, b]);
+        const removed = { ...findModified(msc, 'a') };
+        msc.setSeries([b]);
+
+        msc.moveSeries({ draggedSeries: removed, axisIndex: '0', graphIndex: 'bottom' });
+
+        expect(graphNames(msc)).to.deep.equal([['b']]);
+    });
+
+    it('assigns distinct colors to series added after removals', () => {
+        const msc = controller();
+        const a = makeSeries('a');
+        const b = makeSeries('b');
+        msc.setSeries([a, b]);
+
+        // remove a; b keeps its color (the second line color)
+        msc.setSeries([b]);
+
+        // add c: it must not collide with b
+        const c = makeSeries('c');
+        msc.setSeries([b, c]);
+
+        const colorB = findModified(msc, 'b').color;
+        const colorC = findModified(msc, 'c').color;
+        expect(colorB).to.not.equal(colorC);
+    });
+
+    it('keeps colors unique through add/remove churn until the palette is exhausted', () => {
+        const msc = controller();
+        let active = [];
+        for (let i = 0; i < LINE_COLORS.length; i++) {
+            active = [...active, makeSeries(`s${i}`)];
+            msc.setSeries(active);
+            // remove and re-add an early series to churn the bookkeeping
+            if (i === 3) {
+                const removed = active.splice(1, 1)[0];
+                msc.setSeries(active);
+                active.push(makeSeries(removed.name));
+                msc.setSeries(active);
+            }
+        }
+
+        const colors = msc.multiSeries.flat().map(({ color }) => color);
+        expect(new Set(colors).size).to.equal(colors.length);
+    });
+
+    it('respects explicitly requested colors', () => {
+        const msc = controller();
+        msc.setSeries([makeSeries('a', { color: '#123456' }), makeSeries('b', { color: 3 })]);
+
+        expect(findModified(msc, 'a').color).to.equal('#123456');
+        expect(findModified(msc, 'b').color).to.equal(LINE_COLORS[3]);
+    });
+
+    it('emits graph_count_changed with the new and previous counts', () => {
+        const msc = controller();
+        msc.setSeries([makeSeries('a'), makeSeries('b')]);
+
+        let observed = null;
+        msc.on('graph_count_changed', (count, prevCount) => {
+            observed = { count, prevCount };
+        });
+
+        msc.moveSeries({ draggedSeries: findModified(msc, 'a'), axisIndex: '0', graphIndex: 'bottom' });
+
+        expect(observed).to.deep.equal({ count: 2, prevCount: 1 });
+    });
+});


### PR DESCRIPTION
## What

Fixes the long-standing multigrapher drag-and-drop bugs seen in the tacoma viewer:

- **A dragged variable could end up in two graphs with no way to remove it.** `_multiSeries` retained empty graphs, so numeric drop targets (which are derived from *rendered* position) pointed at the wrong internal graph; `moveSeries` then spliced at `indexOf === -1`, removing an unrelated series and duplicating the dragged one. On top of that, `multigrapherSeriesIndex` values were reused across `setSeries` calls, so `_originalSeriesByMultigrapherIndex` entries got overwritten and a drag could move (or duplicate) the wrong series entirely.
- **Overlapping colors.** Colors were assigned by positional index, so a series added after a removal collided with an existing series' color. New series now take the first line color not currently in use.
- Graph indices were sorted lexicographically (`[0, 10, 2, …]`).
- Dropping a y-axis color box onto the "New grapher" zones did nothing (only series-key items could land there).
- `alert()` on WebGL context failure blocked the page once per graph; the CPU fallback already handles it.
- Positional React keys meant creating a graph at the top (or compacting an emptied one) **remounted every other grapher**, tearing down and re-measuring all canvases at once — likely implicated in the "making a new graph makes everything super tall" reports. Graphs now carry stable identities; `StateController.grapherID` tracks position changes so drop targets keep resolving.
- `sizeCanvas` retried zero-width layouts by measuring the just-reset canvas instead of its container.

`MultigraphStateController` now maintains hard invariants after every change: no empty graphs, `multigrapherGraphIndex` always equals rendered position, series ids are never reused, and bookkeeping is pruned when series disappear.

## Testing

- New unit suite `test/multigraph_state_controller.test.js` (16 tests) covering drop-target resolution after graphs empty, duplicate prevention, placement persistence across series-identity recreation (how tacoma re-creates series), color uniqueness under add/remove churn, and stale-copy drags. Full `npm test` passing (46).
- Browser-verified with headless Chrome on the examples page and inside the tacoma viewer: repeated drags between/into new graphs, graph-position shifts without remounts, stable heights throughout.

## Release note

`src/rust/pkg/index.js` committed on main is stale relative to the rust source (missing the `get_point_number` binding from #12), so the next release build will regenerate it — commit the regenerated glue with the version bump per AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)